### PR TITLE
Fix select field click issue in Darkblue/orange theme

### DIFF
--- a/darkblue_orange/css/theme_right.css.php
+++ b/darkblue_orange/css/theme_right.css.php
@@ -1632,6 +1632,14 @@ td.more_opts {
     white-space: nowrap;
 }
 
+iframe.IE_hack {
+    z-index: 1;
+    position: absolute;
+    display: none;
+    border: 0;
+    filter: alpha(opacity=0);
+}
+
 /* config forms */
 .config-form ul.tabs {
     margin:      1.1em 0.2em 0;


### PR DESCRIPTION
This has been my favorite theme for years and the "add column after" select box functionality on the table structure page has been broken for ages.  I took this fix from the default theme css which stops an IE hack from making the select box unclickable.

I'm a long time phpmyadmin user but this is my first code contribution.  I'm looking forward to making more substantial ones in the future.  Please let me know if you'd like me to do anything else with this.  Hope this is semi-helpful.
