### PR TITLE
fixed lightm_db overlap 

### DIFF
--- a/metro/css/theme_left.css.php
+++ b/metro/css/theme_left.css.php
@@ -370,7 +370,7 @@ div#leftframelinks a:hover img
 div#left_tableList
 {
 	position: absolute;
-	top: 180px;
+	top: 200px;
 	bottom: 0px;
 	width: 250px;
 	overflow-x: hidden;


### PR DESCRIPTION
fixed lightm_db overlap on left_tableList i.e on the left side where table/database  list is shown 
