### PR TITLE
[Fallen] Add background to selected/marked table row

### DIFF
--- a/fallen/css/fallen/common/tables.css.php
+++ b/fallen/css/fallen/common/tables.css.php
@@ -92,7 +92,8 @@ table tr {
 }
 
 td.marked:not(.nomarker), table tr.marked:not(.nomarker) td, table tbody:first-of-type tr.marked:not(.nomarker) th, table tr.marked:not(.nomarker) {
-  color: <?php echo $GLOBALS['cfg']['MainColor'] ?>
+  color: <?php echo $GLOBALS['cfg']['MainColor'] ?>;
+  background: #4285f438;
 }
 
 td.marked:not(.nomarker) {


### PR DESCRIPTION
It's annoying not having a selected background on tables with a lot of rows, you have to be based solely on the blue marker on the beginning, often having to get back just to check if it's selected.